### PR TITLE
Fix MacOS path for removing plugin from quarantine

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the developer cannot be verified" can be bypassed by running the following
 in Terminal (Finder > Applications > Utilities):
 
 ```
-sudo xattr -r -d com.apple.quarantine /Applications/Adobe\ Photoshop\ 2022/Plug-ins/WebPShop.plugin
+sudo xattr -r -d com.apple.quarantine /Library/Application Support/Adobe/Plug-Ins/CC/WebPShop.plugin
 ```
 
 ## Features


### PR DESCRIPTION
Installation path and plugin location did not match.